### PR TITLE
Orchestrated rollout example.

### DIFF
--- a/example/orchestrated/README.md
+++ b/example/orchestrated/README.md
@@ -1,0 +1,22 @@
+This demonstrates using an external coordinator process to safely perform
+a rolling restart of a cluster to update it to a new version.
+
+On a control node, set the active version:
+
+    curl -X PUT  localhost:8500/v1/kv/version -d 'abc123'
+
+On each vagrant node, after starting consul, start a restarter:
+
+    cd /vagrant/example/orchestrated && ruby2.1 -I../../lib restarter.rb
+
+On one arbitrary node, start a coordinator:
+
+    cd /vagrant/example/orchestrated && ruby2.1 -I../../lib coordinator.rb
+
+Now change the active version:
+
+    curl -X PUT  localhost:8500/v1/kv/version -d 'abc456'
+
+Observe that all restarters are updated to the latest version, while
+maintaining at least `MIN_NODES` (default: 1) healthy at all times. This
+process is resilient to crashes in any process.

--- a/example/orchestrated/coordinator.rb
+++ b/example/orchestrated/coordinator.rb
@@ -1,0 +1,89 @@
+require 'consul/client'
+require 'base64'
+
+require_relative '../dropwizard_logger'
+
+$logger  = DropwizardLogger.new('coordinator', $stdout)
+$version = nil
+$health  = nil
+$queue   = Queue.new
+$consul  = Consul::Client.v1.http(logger: $logger)
+
+MIN_NODES = 1
+
+Thread.abort_on_exception = true
+
+# Watch for changes to required version
+Thread.new do
+  loop do
+    v = nil
+    $consul.get_while("/kv/version") do |data|
+      v = Base64.decode64(data[0]['Value'])
+      v == $version
+    end
+    $version = v
+
+    $queue.push(true)
+  end
+end
+
+# Watch for changes to session membership
+Thread.new do
+  loop do
+    $health = $consul.get_while("/health/service/http") do |data|
+      data == $health
+    end
+
+    $queue.push(true)
+  end
+end
+
+# Loop everytime something changes.
+while $queue.pop
+  next unless $version && $health
+
+  # Discard redundant updates.
+  next if $queue.size > 0
+
+  incorrect_nodes = $health.select {|x|
+    !x['Service']['Tags'].include?($version)
+  }
+  $logger.info("#{$version}: #{incorrect_nodes.size} incorrect nodes")
+
+  # If all nodes are running correct version, no action is necessary.
+  next if incorrect_nodes.empty?
+
+  healthy_nodes = $health.select {|x|
+    x['Checks'].all? {|c| c['Status'] == 'passing' }
+  }
+
+  $logger.info("#{$version}: #{healthy_nodes.size} healthy nodes")
+  restarting_nodes = $health.select {|x|
+    node = x['Node']['Node']
+    data = $consul.get("/kv/nodes/#{node}/status")
+    Base64.decode64(data[0]['Value']) == "down".to_json
+  }
+  $logger.info("#{restarting_nodes.size} restarting nodes")
+
+  # Exclude already restarting nodes from our calculations. We need to assume
+  # that if they are not unhealthy already, they could become so at any moment.
+  incorrect_nodes -= restarting_nodes
+  healthy_nodes -= restarting_nodes
+
+  $logger.info("#{$version}: #{incorrect_nodes.size} incorrect nodes minus restarting")
+  $logger.info("#{$version}: #{healthy_nodes.size} healthy nodes minus restarting")
+
+  # Ensure that there is always a minimum number of nodes in the cluster,
+  # regardless of what version they are running. Per above, this calculation
+  # excludes nodes that are already flagged for a restart.
+  number_to_restart = healthy_nodes.size - MIN_NODES
+  next unless number_to_restart > 0
+
+  # Communicate to nodes that they are safe to restart. Individual nodes will
+  # clear this flag on startup, even if it isn't healthy yet.
+  $logger.info("#{$version}: #{number_to_restart} to restart")
+  incorrect_nodes.take(number_to_restart).each do |x|
+    node = x['Node']['Node']
+    $consul.put("/kv/nodes/#{node}/status", "down")
+  end
+end

--- a/example/orchestrated/restarter.rb
+++ b/example/orchestrated/restarter.rb
@@ -1,0 +1,85 @@
+require 'webrick'
+
+require 'consul/client'
+require 'base64'
+
+require_relative '../dropwizard_logger'
+
+PORT = 8888
+
+$logger  = DropwizardLogger.new('app', $stdout)
+$healthy = true
+$version = nil
+$consul  = Consul::Client.v1.http(logger: $logger)
+
+def start_with_latest_version
+  # Here the service is down and is where you would symlink in latest version.
+  # This demo doesn't just keeps the version in a global instead, since the
+  # symlink part isn't relevant.
+
+  # Ensure the service registration is present and has a tag matching the
+  # version we are running. This will be present but unhealthy until the
+  # service actually starts up.
+  $version = Base64.decode64($consul.get("/kv/version")[0]['Value'])
+  $consul.put("/agent/service/register",
+    Name: 'http',
+    Tags: [$version],
+    Check: {
+      Script: "curl --fail localhost:#{PORT}/_status > /dev/null 2>&1",
+      Interval: "1s"
+    }
+  )
+
+  # Clear restart flag
+  node = $consul.get("/agent/self")["Member"]["Name"]
+  $consul.put("/kv/nodes/#{node}/status", "up")
+
+  # Start up with arbitrary sleep just for testing to simulate start up time.
+  # "sv up"
+  sleep 3
+  $healthy = true
+end
+
+# Here we run a server in-process just for simplicity.
+# In reality we would be monitoring a separate process.
+server = WEBrick::HTTPServer.new \
+  :Port   => PORT,
+  :Logger => DropwizardLogger.new("webrick", $stdout).tap {|x|
+              x.level = Logger::INFO
+            },
+  :AccessLog => [[$stdout, DropwizardLogger.webrick_format("webrick")]]
+
+server.mount_proc '/_status' do |req, res|
+  if $healthy
+    $logger.info($version)
+    res.status = 200
+  else
+    res.status = 503
+  end
+end
+
+Thread.abort_on_exception = true
+Thread.new do
+  loop do
+    # Block until restart flag is set
+    node = $consul.get("/agent/self")["Member"]["Name"]
+    $consul.get_while("/kv/nodes/#{node}/status") do |data|
+      Base64.decode64(data[0]['Value']) != "down".to_json
+    end
+
+    # Trigger graceful shutdown. "sv down"
+    $healthy = false
+
+    # Wait until the consistent view of service membership excludes this node
+    # before progressing. This is important to avoid a race condition loop
+    # where we clear our restart flag and the coordinator sets it again because
+    # it still thinks we're healthy.
+    local = Consul::Client.v1.local_service("http", logger: $logger)
+    local.wait_until_unhealthy!
+
+    start_with_latest_version
+  end
+end
+
+start_with_latest_version
+server.start


### PR DESCRIPTION
@anthonybishopric @syamp demo of rollout process we were talking about yesterday. I chose an arbitrary "ensure min nodes" strategy for the orchestrator, but you could easily sub in another one (i.e. "rollout 4 nodes at a time and pay attention to metrics").

It's nice because even though it appears the coordinator is running a "synchronous" rollout, it is responsive to changes in cluster topology. If a down node came up a day later it would correctly be migrated to the current version. If half the cluster crashes, it slows down the rollout and/or halts it if there aren't enough healthy nodes to progress.
