### PR TITLE
Fix circular dependency warning

### DIFF
--- a/lib/consul/client.rb
+++ b/lib/consul/client.rb
@@ -31,7 +31,7 @@ module Consul
       # @example
       #     local = Consul::Client.v1.local_service('web')
       #     local.coordinated_shutdown! { $healthy = false }
-      def local_service(name, http:Consul::Client.v1.http, logger:http.logger)
+      def local_service(name, http:Consul::Client.v1.http(), logger:http.logger)
         LocalService.new(name, http: http, logger: logger)
       end
 


### PR DESCRIPTION
lib/consul/client.rb:34: warning: circular argument reference - http

Signed-off-by: steigr me@stei.gr
